### PR TITLE
Similarity metrics

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -224,6 +224,18 @@ html,
 }
 
 /**
+* Similarity Metric
+**/
+
+.slideshow-simval {
+	width:100%;
+	height:5px;
+	border:1px solid black;
+	box-sizing: border-box;
+	margin-bottom:1px;
+}
+
+/**
 * Captions
 **/
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -227,12 +227,16 @@ html,
 * Similarity Metric
 **/
 
-.slideshow-simval {
-	width:100%;
-	height:5px;
-	border:1px solid black;
-	box-sizing: border-box;
-	margin-bottom:1px;
+.slideshow-similarity {
+  width: 100%;
+  height: 3px;
+  margin-bottom: 2px;
+  background: #ededed;
+}
+
+.similarity-bar {
+  background: #eab755;
+  height: 100%;
 }
 
 /**
@@ -251,7 +255,7 @@ html,
   word-wrap: break-word;
   white-space: normal;
   display: none;
-  margin-top: -5px;
+  margin-top: -2px;
 }
 
 body.captions .slideshow-item.loaded .caption,

--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -296,7 +296,9 @@
           caption.innerHTML = ' [' + Math.round(nn.similarity*100) + '%]';
         }
         var simdiv = container.querySelector('.slideshow-simval');
-        simdiv.setAttribute('style', 'background: -moz-linear-gradient(left, #eab755 ' + Math.round(nn.similarity*100) + '%, #ededed ' + (100-(parseInt(Math.round(nn.similarity*100)))) + '%);background: -ms-linear-gradient(left, #eab755 ' + Math.round(nn.similarity*100) + '%, #ededed ' + (100-(parseInt(Math.round(nn.similarity*100)))) + '%);background: linear-gradient(left, #eab755 ' + Math.round(nn.similarity*100) + '%, #ededed ' + (100-(parseInt(Math.round(nn.similarity*100)))) + '%);background: -webkit-linear-gradient(left, #eab755 ' + Math.round(nn.similarity*100) + '%, #ededed ' + (100-(parseInt(Math.round(nn.similarity*100)))) + '%);'); 
+        var fuel = Math.round(nn.similarity*100);
+        var empty = (100-(parseInt(fuel)));
+        simdiv.setAttribute('style', 'background: -moz-linear-gradient(left, #eab755 ' + fuel + '%, #ededed ' + empty + '%);background: -ms-linear-gradient(left, #eab755 ' + fuel + '%, #ededed ' + empty + '%);background: -webkit-linear-gradient(left, #eab755 ' + fuel + '%, #ededed ' + empty + '%);background: linear-gradient(left, #eab755 ' + fuel + '%, #ededed ' + empty + '%);'); 
 
       })
 

--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -13,7 +13,8 @@
       // selectors
       galleryItemClass = 'gallery-item', // className of each grid item
       galleryImageClass = 'gallery-image', // className of each gallery image
-      galleryItemSimValClass = 'slideshow-simval', // className of each similarity value
+      similarityClass = 'slideshow-similarity', // className of each similarity value
+      similarityBarClass = 'similarity-bar', // className of the similarity bar
       slideshowItemClass = 'slideshow-item', // className of each slideshow item
 
       // parameters
@@ -87,10 +88,14 @@
       var div = document.createElement('div');
       div.className = slideshowItemClass;
 
-      // add the similarity value div
-      var simdiv = document.createElement('div');
-      simdiv.className = galleryItemSimValClass;
-          
+      // add the similarity value container
+      var similarityDiv = document.createElement('div');
+      similarityDiv.className = similarityClass;
+
+      // add the similarity value bar
+      var similarityBar = document.createElement('div');
+      similarityBar.className = similarityBarClass;
+
       // add the image
       var img = document.createElement('img');
       img.src = ' ';
@@ -99,8 +104,9 @@
       var caption = document.createElement('div');
       caption.className = 'caption';
 
-      div.appendChild(simdiv);
+      similarityDiv.appendChild(similarityBar);
       div.appendChild(img);
+      div.appendChild(similarityDiv);
       div.appendChild(caption);
       slideshow.appendChild(div);
     })
@@ -277,8 +283,10 @@
       var containers = slideshow.querySelectorAll('.' + slideshowItemClass);
 
       _.take(nearestNeighbors, slideshowImages).forEach(function(nn, idx) {
-        var container = containers[idx];
-        var img = container.querySelector('img');
+        var container = containers[idx],
+            img = container.querySelector('img'),
+            similarity = Math.round(nn.similarity*100);
+
         img.onload = function() {
           var parent = this.parentNode;
           var parentClass = parent.className;
@@ -289,17 +297,14 @@
         if (nn.caption) {
           var parentClass = caption.parentNode.className.replace(' hidden', '');
           caption.parentNode.setAttribute('class', parentClass);
-          caption.innerHTML = nn.caption + ' [' + Math.round(nn.similarity*100) + '%]';
+          caption.innerHTML = nn.caption + ' [' + similarity + '%]';
         } else {
           var parentClass = caption.parentNode.className + ' hidden';
           caption.parentNode.setAttribute('class', parentClass);
-          caption.innerHTML = ' [' + Math.round(nn.similarity*100) + '%]';
+          caption.innerHTML = ' [' + similarity + '%]';
         }
-        var simdiv = container.querySelector('.slideshow-simval');
-        var fuel = Math.round(nn.similarity*100);
-        var empty = (100-(parseInt(fuel)));
-        simdiv.setAttribute('style', 'background: -moz-linear-gradient(left, #eab755 ' + fuel + '%, #ededed ' + empty + '%);background: -ms-linear-gradient(left, #eab755 ' + fuel + '%, #ededed ' + empty + '%);background: -webkit-linear-gradient(left, #eab755 ' + fuel + '%, #ededed ' + empty + '%);background: linear-gradient(left, #eab755 ' + fuel + '%, #ededed ' + empty + '%);'); 
-
+        var similarityBar = container.querySelector('.' + similarityBarClass);
+        similarityBar.style.width = similarity + '%';
       })
 
       slideshow.style.display = 'block';

--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -13,6 +13,7 @@
       // selectors
       galleryItemClass = 'gallery-item', // className of each grid item
       galleryImageClass = 'gallery-image', // className of each gallery image
+      galleryItemSimValClass = 'slideshow-simval', // className of each similarity value
       slideshowItemClass = 'slideshow-item', // className of each slideshow item
 
       // parameters
@@ -86,6 +87,10 @@
       var div = document.createElement('div');
       div.className = slideshowItemClass;
 
+      // add the similarity value div
+      var simdiv = document.createElement('div');
+      simdiv.className = galleryItemSimValClass;
+          
       // add the image
       var img = document.createElement('img');
       img.src = ' ';
@@ -94,6 +99,7 @@
       var caption = document.createElement('div');
       caption.className = 'caption';
 
+      div.appendChild(simdiv);
       div.appendChild(img);
       div.appendChild(caption);
       slideshow.appendChild(div);
@@ -283,12 +289,15 @@
         if (nn.caption) {
           var parentClass = caption.parentNode.className.replace(' hidden', '');
           caption.parentNode.setAttribute('class', parentClass);
-          caption.innerHTML = nn.caption;
+          caption.innerHTML = nn.caption + ' [' + Math.round(nn.similarity*100) + '%]';
         } else {
           var parentClass = caption.parentNode.className + ' hidden';
           caption.parentNode.setAttribute('class', parentClass);
-          caption.innerHTML = '';
+          caption.innerHTML = ' [' + Math.round(nn.similarity*100) + '%]';
         }
+        var simdiv = container.querySelector('.slideshow-simval');
+        simdiv.setAttribute('style', 'background: -moz-linear-gradient(left, #eab755 ' + Math.round(nn.similarity*100) + '%, #ededed ' + (100-(parseInt(Math.round(nn.similarity*100)))) + '%);background: -ms-linear-gradient(left, #eab755 ' + Math.round(nn.similarity*100) + '%, #ededed ' + (100-(parseInt(Math.round(nn.similarity*100)))) + '%);background: linear-gradient(left, #eab755 ' + Math.round(nn.similarity*100) + '%, #ededed ' + (100-(parseInt(Math.round(nn.similarity*100)))) + '%);background: -webkit-linear-gradient(left, #eab755 ' + Math.round(nn.similarity*100) + '%, #ededed ' + (100-(parseInt(Math.round(nn.similarity*100)))) + '%);'); 
+
       })
 
       slideshow.style.display = 'block';


### PR DESCRIPTION
This branch -- which should definitely be tested :) -- exposes the similarity metric in two ways: a visual "fuel gauge" above each similar image, and a numerical percentage suffixed to the caption. It does depend on `similarity` values in the underlying json.

![similarity-metric](https://user-images.githubusercontent.com/1000161/29185635-d441507e-7dd7-11e7-9e3b-42926273e553.jpg)
